### PR TITLE
gemspec:  Add RubyGems metadata

### DIFF
--- a/time_calc.gemspec
+++ b/time_calc.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email    = 'zverok.offline@gmail.com'
   s.homepage = 'https://github.com/zverok/time_calc'
   s.metadata = {
-    'bug_tracker_uri' => "https://github.com/zverok/time_calc/issues',
+    'bug_tracker_uri' => 'https://github.com/zverok/time_calc/issues',
     'changelog_uri' => 'https://github.com/zverok/time_calc/blob/master/Changelog.md',
     'documentation_uri' => 'https://www.rubydoc.info/gems/time_calc/',
     'homepage_uri' => 'https://github.com/zverok/time_calc',

--- a/time_calc.gemspec
+++ b/time_calc.gemspec
@@ -6,6 +6,13 @@ Gem::Specification.new do |s|
   s.authors  = ['Victor Shepelev']
   s.email    = 'zverok.offline@gmail.com'
   s.homepage = 'https://github.com/zverok/time_calc'
+  s.metadata = {
+    'bug_tracker_uri' => "https://github.com/zverok/time_calc/issues',
+    'changelog_uri' => 'https://github.com/zverok/time_calc/blob/master/Changelog.md',
+    'documentation_uri' => 'https://www.rubydoc.info/gems/time_calc/',
+    'homepage_uri' => 'https://github.com/zverok/time_calc',
+    'source_code_uri' => 'https://github.com/zverok/time_calc'
+  }
 
   s.summary = 'Easy time math'
   s.description = <<-EOF


### PR DESCRIPTION
This PR adds RubyGems metadata section, which is the API to add/remove data to the RubyGems.org page.
