### PR TITLE
New aliases add & sub

### DIFF
--- a/lib/time_calc.rb
+++ b/lib/time_calc.rb
@@ -315,6 +315,9 @@ class TimeCalc
     #   # @return [Op]
     #   def TimeCalc.round(unit); end
   end
+
+  alias add +
+  alias sub -
 end
 
 require_relative 'time_calc/op'

--- a/lib/time_calc/op.rb
+++ b/lib/time_calc/op.rb
@@ -54,6 +54,9 @@ class TimeCalc
     #   @see TimeCalc#round
     #   @return [Op]
 
+    alias add +
+    alias sub -
+
     # Performs the whole chain of operation on parameter, returning the result.
     #
     # @param date_or_time [Date, Time, DateTime]

--- a/lib/time_calc/value.rb
+++ b/lib/time_calc/value.rb
@@ -158,6 +158,8 @@ class TimeCalc
       end
     end
 
+    alias add +
+
     # @overload -(span, unit)
     #   Subtracts `span units` from wrapped value.
     #   @param span [Integer]
@@ -171,6 +173,8 @@ class TimeCalc
     def -(span_or_other, unit = nil)
       unit.nil? ? Diff.new(self, span_or_other) : self.+(-span_or_other, unit)
     end
+
+    alias sub -
 
     # Like {#+}, but allows conditional skipping of some periods. Increases value by `unit`
     # at least `span` times, on each iteration checking with block provided if this point

--- a/spec/time_calc/value_math_spec.rb
+++ b/spec/time_calc/value_math_spec.rb
@@ -4,25 +4,27 @@ require 'time_calc/value'
 
 RSpec.describe TimeCalc::Value, 'math' do
   {
-    plus: :+,
-    minus: :-,
+    plus: [:+, :add],
+    minus: [:-, :sub],
     floor: :floor,
     ceil: :ceil
     # round: :round
-  }.each do |filename, sym|
-    describe "##{sym}" do
-      CSV.read("spec/fixtures/#{filename}.csv")
-         .reject { |r| r.first.start_with?('#') } # hand-made CSV comments!
-         .each do |source, *args, expected_str|
-        context "#{source} #{sym} #{args.join(' ')}" do
-          subject { value.public_send(sym, *real_args).unwrap }
+  }.each do |filename, symbols|
+    Array(symbols).each do |sym|
+      describe "##{sym}" do
+        CSV.read("spec/fixtures/#{filename}.csv")
+          .reject { |r| r.first.start_with?('#') } # hand-made CSV comments!
+          .each do |source, *args, expected_str|
+            context "#{source} #{sym} #{args.join(' ')}" do
+              subject { value.public_send(sym, *real_args).unwrap }
 
-          let(:value) { described_class.new(t(source)) }
-          let(:expected) { t(expected_str) }
-          let(:real_args) { args.count == 1 ? args.last.to_sym : [args.first.to_r, args.last.to_sym] }
+              let(:value) { described_class.new(t(source)) }
+              let(:expected) { t(expected_str) }
+              let(:real_args) { args.count == 1 ? args.last.to_sym : [args.first.to_r, args.last.to_sym] }
 
-          it { is_expected.to eq expected }
-        end
+              it { is_expected.to eq expected }
+            end
+          end
       end
     end
   end


### PR DESCRIPTION
Here is a proposal. I'm not convinced by the `.+()` syntax, it doesn't seem natural to me. That's why I propose two aliases:

```ruby
alias_method :add, :+ 
alias_method :sub, :- 
```

Usage: 

```ruby
irb(main):001:0> Date.today
=> #<Date: 2021-02-05 ((2459251j,0s,0n),+0s,2299161j)>
irb(main):002:0> TimeCalc.today.add(4, :days)
=> #<Date: 2021-02-09 ((2459255j,0s,0n),+0s,2299161j)>
irb(main):003:0> TimeCalc.today.sub(4, :days)
=> #<Date: 2021-02-01 ((2459247j,0s,0n),+0s,2299161j)>
```